### PR TITLE
Fix $GLOBALS['TL_DCA'][$table]['fields'][$field] being null

### DIFF
--- a/src/Group/Registry.php
+++ b/src/Group/Registry.php
@@ -75,7 +75,7 @@ class Registry
     {
         return array_keys(
             array_filter(
-                $GLOBALS['TL_DCA'][$table]['fields'] ?? [],
+                array_filter($GLOBALS['TL_DCA'][$table]['fields'] ?? []),
                 static fn (array $definition): bool => 'group' === ($definition['inputType'] ?? null)
             )
         );


### PR DESCRIPTION
Don't ask my why, but $GLOBALS['TL_DCA'][$table]['fields'][$field] can be NULL. This is the case for some fields added by the news_categories extension added to tl_content.
This resulted in a fatal error.