### PR TITLE
Submit form when a subpalette gets loaded

### DIFF
--- a/Resources/views/widget_group_reloader.html.twig
+++ b/Resources/views/widget_group_reloader.html.twig
@@ -1,0 +1,8 @@
+<script type="application/javascript">Backend.autoSubmit('{{ table }}');</script>
+
+<div class="tl_box">
+    <div class="widget">
+        {# Contao default spinner #}
+        <img src="system/themes/flexible/icons/loading.svg" alt="Loading…" width="20px" height="20px">
+    </div>
+</div>

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -8,6 +8,7 @@ services:
     arguments:
       - '@request_stack'
       - '@Mvo\ContaoGroupWidget\Group\Registry'
+      - '@twig'
 
   Mvo\ContaoGroupWidget\Storage\SerializedStorageFactory:
     arguments:

--- a/tests/EventListener/GroupWidgetListenerTest.php
+++ b/tests/EventListener/GroupWidgetListenerTest.php
@@ -18,6 +18,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Twig\Environment;
 
 class GroupWidgetListenerTest extends TestCase
 {
@@ -38,7 +39,8 @@ class GroupWidgetListenerTest extends TestCase
 
         $listener = new GroupWidgetListener(
             $requestStack,
-            new Registry($this->createMock(ContainerInterface::class), new ArrayIteratorAggregate())
+            new Registry($this->createMock(ContainerInterface::class), new ArrayIteratorAggregate()),
+            $this->createMock(Environment::class)
         );
 
         $GLOBALS['TL_DCA']['tl_foo']['fields'] = $fields;
@@ -188,7 +190,11 @@ class GroupWidgetListenerTest extends TestCase
         $requestStack = new RequestStack();
         $requestStack->push($request);
 
-        $listener = new GroupWidgetListener($requestStack, $registry);
+        $listener = new GroupWidgetListener(
+            $requestStack,
+            $registry,
+            $this->createMock(Environment::class),
+        );
 
         $dataContainer = $this->createMock(DataContainer::class);
         $dataContainer
@@ -250,7 +256,8 @@ class GroupWidgetListenerTest extends TestCase
 
         $listener = new GroupWidgetListener(
             $this->createMock(RequestStack::class),
-            $registry
+            $registry,
+            $this->createMock(Environment::class)
         );
 
         $dataContainer = $this->createMock(DataContainer::class);
@@ -295,7 +302,8 @@ class GroupWidgetListenerTest extends TestCase
 
         $listener = new GroupWidgetListener(
             $this->createMock(RequestStack::class),
-            $registry
+            $registry,
+            $this->createMock(Environment::class)
         );
 
         $dataContainer = $this->createMock(DataContainer::class);
@@ -334,7 +342,8 @@ class GroupWidgetListenerTest extends TestCase
 
         $listener = new GroupWidgetListener(
             $this->createMock(RequestStack::class),
-            $registry
+            $registry,
+            $this->createMock(Environment::class)
         );
 
         $dataContainer = $this->createMock(DataContainer::class);
@@ -374,7 +383,8 @@ class GroupWidgetListenerTest extends TestCase
 
         $listener = new GroupWidgetListener(
             $this->createMock(RequestStack::class),
-            $registry
+            $registry,
+            $this->createMock(Environment::class)
         );
 
         $dataContainer = $this->createMock(DataContainer::class);


### PR DESCRIPTION
Fixes #26 

With this PR a group widget in a subpalette that's currently invisible will cause the form to submit once shown. This is a bit hacky, but I think there currently is no cleaner way to do it because we need to create all the virtual fields. 

/cc @bytehead