### PR TITLE
Prefer explicitly defined group element label

### DIFF
--- a/src/Group/Group.php
+++ b/src/Group/Group.php
@@ -361,6 +361,10 @@ class Group
 
     private function applyMinMaxConstraints(array $elementIds): array
     {
+        if (null === $this->storage) {
+            throw new \RuntimeException('Cannot apply min/max constraints if no storage back end is set.');
+        }
+
         // Apply min/max constraints
         $size = \count($elementIds);
 
@@ -445,10 +449,10 @@ class Group
 
         // Set a default label
         if (!\array_key_exists('label', $definition)) {
-            if (\array_key_exists($name, $GLOBALS['TL_DCA'][$this->table]['fields'])) {
-                $definition['label'] = &$GLOBALS['TL_LANG'][$this->table][$name];
-            } else {
+            if (\array_key_exists($name, $GLOBALS['TL_LANG'][$this->table]["{$this->name}_"] ?? [])) {
                 $definition['label'] = &$GLOBALS['TL_LANG'][$this->table]["{$this->name}_"][$name];
+            } else {
+                $definition['label'] = &$GLOBALS['TL_LANG'][$this->table][$name];
             }
         }
 

--- a/tests/Group/GroupTest.php
+++ b/tests/Group/GroupTest.php
@@ -255,6 +255,10 @@ class GroupTest extends TestCase
             ],
         ];
 
+        // Check default labels are being assigned
+        $GLOBALS['TL_LANG']['tl_foo']['foo'] = ['foo label'];
+        $GLOBALS['TL_LANG']['tl_foo']['my_group_']['bar'] = ['my_group.bar label'];
+
         $twig = $this->createMock(Environment::class);
         $locator = $this->createMock(ContainerInterface::class);
 
@@ -282,7 +286,7 @@ class GroupTest extends TestCase
             'sql' => null,
             'load_callback' => [[GroupWidgetListener::class, 'onLoadGroupField']],
             'save_callback' => [[GroupWidgetListener::class, 'onStoreGroupField']],
-            'label' => null,
+            'label' => ['foo label'],
         ];
 
         $expectedBarDefinition = [
@@ -293,7 +297,7 @@ class GroupTest extends TestCase
             'sql' => null,
             'load_callback' => [[GroupWidgetListener::class, 'onLoadGroupField']],
             'save_callback' => [[GroupWidgetListener::class, 'onStoreGroupField']],
-            'label' => null,
+            'label' => ['my_group.bar label'],
         ];
 
         $expectedFields = [
@@ -333,15 +337,15 @@ class GroupTest extends TestCase
 
         self::assertEquals($expectedPalette, $GLOBALS['TL_DCA']['tl_foo']['palettes']['default']);
 
-        // Check default labels are being assigned
-        $GLOBALS['TL_LANG']['tl_foo']['foo'] = ['foo label'];
-        $GLOBALS['TL_LANG']['tl_foo']['my_group_']['bar'] = ['my_group.bar label'];
+        // Check default labels are references
+        $GLOBALS['TL_LANG']['tl_foo']['foo'] = ['another foo label'];
+        $GLOBALS['TL_LANG']['tl_foo']['my_group_']['bar'] = ['another bar label'];
 
-        self::assertEquals(['foo label'], $GLOBALS['TL_DCA']['tl_foo']['fields']['my_group__foo__1']['label']);
-        self::assertEquals(['foo label'], $GLOBALS['TL_DCA']['tl_foo']['fields']['my_group__foo__2']['label']);
+        self::assertEquals(['another foo label'], $GLOBALS['TL_DCA']['tl_foo']['fields']['my_group__foo__1']['label']);
+        self::assertEquals(['another foo label'], $GLOBALS['TL_DCA']['tl_foo']['fields']['my_group__foo__2']['label']);
 
-        self::assertEquals(['my_group.bar label'], $GLOBALS['TL_DCA']['tl_foo']['fields']['my_group__bar__1']['label']);
-        self::assertEquals(['my_group.bar label'], $GLOBALS['TL_DCA']['tl_foo']['fields']['my_group__bar__2']['label']);
+        self::assertEquals(['another bar label'], $GLOBALS['TL_DCA']['tl_foo']['fields']['my_group__bar__1']['label']);
+        self::assertEquals(['another bar label'], $GLOBALS['TL_DCA']['tl_foo']['fields']['my_group__bar__2']['label']);
     }
 
     public function testGetField(): void


### PR DESCRIPTION
This change makes sure an explicitly defined group element label is favored over a similar named field inside the DCA.

#### Why is this needed?
If you've got a field `foo` in your DCA and a group `my_group` with a group field (not shared) that is also named `foo`, you could not use the `_my_group.foo` (or `$langArray['_my_group']['foo'] = '…'`) label schema as the default would always point to the label of the DCA field. 