### PR TITLE
Use raw output of description

### DIFF
--- a/Resources/views/widget_group.html.twig
+++ b/Resources/views/widget_group.html.twig
@@ -7,7 +7,7 @@
             {% if group.label %}
                 <h3>{{ group.label }}</h3>
                 {% if group.description %}
-                    <p class="tl_help tl_tip">{{ group.description }}</p>
+                    <p class="tl_help tl_tip">{{ group.description|raw }}</p>
                 {% endif %}
             {% endif %}
         </div>


### PR DESCRIPTION
In Contao you are able to use HTML tags in the description part of the label for each back end field. This currently does not work in this extension though:

![image](https://user-images.githubusercontent.com/4970961/155517630-b35de21e-c5e4-4cd1-b89e-558e34fec115.png)

This PR enables raw output for the description.