### PR TITLE
Fix missing & in docs

### DIFF
--- a/docs/data-definition.md
+++ b/docs/data-definition.md
@@ -41,7 +41,7 @@ $GLOBALS['TL_DCA']['tl_my_dca']['fields']['my_group_field'] = [
     'inputType' => 'group',
     'palette' => ['text', 'singleSRC'],
     'fields' => [
-        'text' => [
+        '&text' => [
             'eval' => ['tl_class' => 'w50'],
         ]
     ],


### PR DESCRIPTION
If I had read the docs correct, there should be an & before the text field definition. But maybe I'm wrong, then we can just forget this PR :)