### PR TITLE
Add support for DC Multilingual

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -1,8 +1,9 @@
 services:
   Mvo\ContaoGroupWidget\Group\Registry:
     arguments:
-      - !service_locator
-        twig: '@twig'
+      - '@twig'
+      - '@request_stack'
+      - '@database_connection'
       - !tagged_iterator 'mvo_contao_group.storage_factory'
 
   Mvo\ContaoGroupWidget\EventListener\GroupWidgetListener:

--- a/docs/data-definition.md
+++ b/docs/data-definition.md
@@ -153,6 +153,7 @@ If you want to deviate from this, just add your own `label` definition like
 usual.
 
 ## Various
+### Styling
 Similarly to other Contao widgets, setting a `tl_class` or `style` under the 
 `eval` is possible and will be applied to the group widget container:
 
@@ -165,5 +166,30 @@ $GLOBALS['TL_DCA']['tl_my_dca']['fields']['my_group_field'] = [
         'tl_class' => 'w50',
         'style' => 'background-color: rebeccapurple;' // wtf 
     ],  
+];
+````
+
+### DC_Multilingual
+The group widget also has build-in support for [terminal42/contao-DC_Multilingual](https://github.com/terminal42/contao-DC_Multilingual). 
+Make sure to add an `['eval']['translatableFor'] = '…'` entry to each group
+field definition that should be affected.
+
+Note, that you won't be able to match fallback values across translations,
+because an editor will create/remove/reorder each group individually. For the
+typical use case, you therefore want to set the value to `*` for all fields:
+
+```php
+$GLOBALS['TL_DCA']['tl_my_dca']['fields']['my_group_field'] = [
+    'inputType' => 'group',
+    'fields' => [
+        'my_headline' => [
+            'inputType' => 'text',
+            'eval' => ['mandatory' => true, 'translatableFor' => '*'],
+        ],
+        'my_description' => [
+            'inputType' => 'textarea',
+            'eval' => ['tl_class' => 'clr', 'translatableFor' => '*'],
+        ],
+    ],
 ];
 ```

--- a/src/Group/Registry.php
+++ b/src/Group/Registry.php
@@ -69,7 +69,7 @@ class Registry
 
     public function getInitializedGroups(string $table, int $rowId): array
     {
-        return $this->groupCache[$this->getCacheKey($table, $rowId)] ?? [];
+        return array_values($this->groupCache[$this->getCacheKey($table, $rowId)] ?? []);
     }
 
     /**

--- a/src/Storage/NullStorage.php
+++ b/src/Storage/NullStorage.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @author  Moritz Vondano
+ * @license MIT
+ */
+
+namespace Mvo\ContaoGroupWidget\Storage;
+
+/**
+ * Dummy storage adapter that doesn't persist anything.
+ *
+ * @internal
+ */
+final class NullStorage implements StorageInterface
+{
+    private int $currentId = 1;
+
+    public function getElements(): array
+    {
+        return [];
+    }
+
+    public function createElement(): int
+    {
+        return $this->currentId++;
+    }
+
+    public function removeElement(int $elementId): void
+    {
+    }
+
+    public function orderElements(array $elementIds): void
+    {
+    }
+
+    public function getField(int $elementId, string $field)
+    {
+        return null;
+    }
+
+    public function setField(int $elementId, string $field, $value): void
+    {
+    }
+
+    public function persist(): void
+    {
+    }
+
+    public function remove(): void
+    {
+    }
+}

--- a/src/Storage/StorageFactoryInterface.php
+++ b/src/Storage/StorageFactoryInterface.php
@@ -15,5 +15,7 @@ interface StorageFactoryInterface
 {
     public static function getName(): string;
 
+    // TODO: make row id part of the storage interface in v2 and remove it from
+    //       being a property of the Group class
     public function create(Group $group): StorageInterface;
 }

--- a/tests/EventListener/GroupWidgetListenerTest.php
+++ b/tests/EventListener/GroupWidgetListenerTest.php
@@ -10,12 +10,12 @@ declare(strict_types=1);
 namespace Mvo\ContaoGroupWidget\Tests\EventListener;
 
 use Contao\DataContainer;
+use Doctrine\DBAL\Connection;
 use Mvo\ContaoGroupWidget\EventListener\GroupWidgetListener;
 use Mvo\ContaoGroupWidget\Group\Group;
 use Mvo\ContaoGroupWidget\Group\Registry;
 use Mvo\ContaoGroupWidget\Tests\Stubs\ArrayIteratorAggregate;
 use PHPUnit\Framework\TestCase;
-use Psr\Container\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Twig\Environment;
@@ -32,10 +32,13 @@ class GroupWidgetListenerTest extends TestCase
         $requestStack = new RequestStack();
         $requestStack->push($request);
 
+        $twig = $this->createMock(Environment::class);
+        $connection = $this->createMock(Connection::class);
+
         $listener = new GroupWidgetListener(
             $requestStack,
-            new Registry($this->createMock(ContainerInterface::class), new ArrayIteratorAggregate()),
-            $this->createMock(Environment::class)
+            new Registry($twig, $requestStack, $connection, new ArrayIteratorAggregate()),
+            $twig
         );
 
         $GLOBALS['TL_DCA']['tl_foo']['fields'] = $fields;

--- a/tests/Group/GroupTest.php
+++ b/tests/Group/GroupTest.php
@@ -14,7 +14,6 @@ use Mvo\ContaoGroupWidget\Group\Group;
 use Mvo\ContaoGroupWidget\Storage\StorageInterface;
 use Mvo\ContaoGroupWidget\Tests\Stubs\DummyStorage;
 use PHPUnit\Framework\TestCase;
-use Psr\Container\ContainerInterface;
 use Twig\Environment;
 
 class GroupTest extends TestCase
@@ -42,7 +41,7 @@ class GroupTest extends TestCase
         ];
 
         $group = new Group(
-            $this->createMock(ContainerInterface::class),
+            $this->createMock(Environment::class),
             'tl_foo',
             123,
             'my_group'
@@ -183,7 +182,7 @@ class GroupTest extends TestCase
         $this->expectExceptionMessage($exception);
 
         new Group(
-            $this->createMock(ContainerInterface::class),
+            $this->createMock(Environment::class),
             'tl_foo',
             123,
             'my_group'
@@ -259,17 +258,8 @@ class GroupTest extends TestCase
         $GLOBALS['TL_LANG']['tl_foo']['foo'] = ['foo label'];
         $GLOBALS['TL_LANG']['tl_foo']['my_group_']['bar'] = ['my_group.bar label'];
 
-        $twig = $this->createMock(Environment::class);
-        $locator = $this->createMock(ContainerInterface::class);
-
-        $locator
-            ->method('get')
-            ->with('twig')
-            ->willReturn($twig)
-        ;
-
         $group = new Group(
-            $locator,
+            $twig = $this->createMock(Environment::class),
             'tl_foo',
             123,
             'my_group'
@@ -511,7 +501,7 @@ class GroupTest extends TestCase
         ];
 
         return new Group(
-            $this->createMock(ContainerInterface::class),
+            $this->createMock(Environment::class),
             'tl_foo',
             123,
             'my_group'

--- a/tests/Group/GroupTest.php
+++ b/tests/Group/GroupTest.php
@@ -377,7 +377,7 @@ class GroupTest extends TestCase
 
         $storage = $this->createMock(StorageInterface::class);
 
-        // Simulate transition [1, 5, 3] with [5, 2, 1, -1] --> [5, 1, 6]
+        // Simulate transition [1, 5, 3] with [2, 5, 1, -1] --> [5, 1, 6]
         //  - should create new item (6)
         //  - should remove item 3
         //  - should ignore unmapped (2)

--- a/tests/Group/RegistryTest.php
+++ b/tests/Group/RegistryTest.php
@@ -15,7 +15,7 @@ use Mvo\ContaoGroupWidget\Tests\Stubs\ArrayIteratorAggregate;
 use Mvo\ContaoGroupWidget\Tests\Stubs\DummyStorage;
 use Mvo\ContaoGroupWidget\Tests\Stubs\DummyStorageFactory;
 use PHPUnit\Framework\TestCase;
-use Psr\Container\ContainerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Twig\Environment;
 
 class RegistryTest extends TestCase
@@ -35,7 +35,9 @@ class RegistryTest extends TestCase
         ];
 
         $registry = new Registry(
-            $this->createMock(ContainerInterface::class),
+            $this->createMock(Environment::class),
+            $this->createMock(RequestStack::class),
+            $this->createMock(Connection::class),
             new ArrayIteratorAggregate()
         );
 
@@ -59,15 +61,6 @@ class RegistryTest extends TestCase
             ],
         ];
 
-        $locator = $this->createMock(ContainerInterface::class);
-        $locator
-            ->method('get')
-            ->willReturnMap([
-                ['twig', $this->createMock(Environment::class)],
-                ['database_connection', $this->createMock(Connection::class)],
-            ])
-        ;
-
         $dummyStorageFactory = $this->createPartialMock(DummyStorageFactory::class, ['create']);
         $dummyStorageFactory
             ->method('create')
@@ -75,7 +68,9 @@ class RegistryTest extends TestCase
         ;
 
         $registry = new Registry(
-            $locator,
+            $this->createMock(Environment::class),
+            $this->createMock(RequestStack::class),
+            $this->createMock(Connection::class),
             new ArrayIteratorAggregate(['dummy' => $dummyStorageFactory])
         );
 

--- a/tests/Storage/DoctrineTestHelper.php
+++ b/tests/Storage/DoctrineTestHelper.php
@@ -65,7 +65,7 @@ class DoctrineTestHelper
         $diff = $connection
             ->getSchemaManager()
             ->createSchema()
-            ->getMigrateToSql($toSchema, $connection->getDatabasePlatform(), )
+            ->getMigrateToSql($toSchema, $connection->getDatabasePlatform())
         ;
 
         foreach ($diff as $sql) {

--- a/vendor-bin/composer-require-checker/config.json
+++ b/vendor-bin/composer-require-checker/config.json
@@ -7,7 +7,8 @@
     "Contao\\ManagerPlugin\\Bundle\\Config\\BundleConfig",
     "Contao\\ManagerPlugin\\Bundle\\Parser\\ParserInterface",
     "Contao\\ManagerPlugin\\Config\\ConfigPluginInterface",
-    "Contao\\ManagerPlugin\\Routing\\RoutingPluginInterface"
+    "Contao\\ManagerPlugin\\Routing\\RoutingPluginInterface",
+    "Terminal42\\DcMultilingualBundle\\Driver"
   ],
   "php-core-extensions" : [
     "Core",

--- a/vendor-bin/ecs/composer.json
+++ b/vendor-bin/ecs/composer.json
@@ -1,6 +1,6 @@
 {
     "require": {
-        "contao/easy-coding-standard": "^3.0"
+        "contao/easy-coding-standard": "^5.3.1"
     },
     "config": {
         "allow-plugins": {

--- a/vendor-bin/ecs/config/default.php
+++ b/vendor-bin/ecs/config/default.php
@@ -2,29 +2,25 @@
 
 declare(strict_types=1);
 
-use Contao\EasyCodingStandard\Sniffs\ContaoFrameworkClassAliasSniff;
+use Contao\EasyCodingStandard\Fixer\TypeHintOrderFixer;
+use Contao\EasyCodingStandard\Sniffs\UseSprintfInExceptionsSniff;
 use PhpCsFixer\Fixer\Comment\HeaderCommentFixer;
 use PhpCsFixer\Fixer\PhpUnit\PhpUnitTestCaseStaticMethodCallsFixer;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\EasyCodingStandard\Config\ECSConfig;
 
-return static function (ContainerConfigurator $containerConfigurator): void {
-    $containerConfigurator->import(__DIR__ . '/../vendor/contao/easy-coding-standard/config/set/contao.php');
+return static function (ECSConfig $ecsConfig): void {
+    $ecsConfig->import(__DIR__ . '/../vendor/contao/easy-coding-standard/config/contao.php');
 
-    $services = $containerConfigurator->services();
+    $ecsConfig->ruleWithConfiguration(HeaderCommentFixer::class, [
+        'header' => "@author  Moritz Vondano\n@license MIT",
+    ]);
 
-    $services
-        ->set(HeaderCommentFixer::class)
-        ->call('configure', [[
-            'header' => "@author  Moritz Vondano\n@license MIT",
-        ]]);
+    $ecsConfig->ruleWithConfiguration(PhpUnitTestCaseStaticMethodCallsFixer::class, [
+        'call_type' => 'self'
+    ]);
 
-    $services
-        ->set(PhpUnitTestCaseStaticMethodCallsFixer::class)
-        ->call('configure', [[
-            'call_type' => 'self',
-        ]])
-    ;
-
-    $services
-        ->set(ContaoFrameworkClassAliasSniff::class, \stdClass::class);
+    $ecsConfig->skip([
+        TypeHintOrderFixer::class,
+        UseSprintfInExceptionsSniff::class,
+    ]);
 };


### PR DESCRIPTION
This PR adds support for DC Multilingual, the relevant commit is 55c7aebac3bc46b88640d0cf7cb56934f2a9d44f.

As soon as at least one of your group fields contains an `'eval' => ['translatableFor' => …]` definition, the group will also be displayed for translations.

In most cases, you'll want to set each of your fields to `translatableFor' => '*'` - otherwise you would not be able to match the correct fallback value in the original/fallback language entry. 

/cc @aschempp