### PR TITLE
Prevent an error if the palette key is not a string (e.g. for Isotope products)

### DIFF
--- a/src/EventListener/GroupWidgetListener.php
+++ b/src/EventListener/GroupWidgetListener.php
@@ -107,11 +107,11 @@ final class GroupWidgetListener
                 continue;
             }
 
-            $addAffectedPalettes($key, $palette, false);
+            $addAffectedPalettes((string) $key, $palette, false);
         }
 
         foreach ($GLOBALS['TL_DCA'][$table]['subpalettes'] ?? [] as $key => $palette) {
-            $addAffectedPalettes($key, $palette, true);
+            $addAffectedPalettes((string) $key, $palette, true);
         }
 
         // Handle form data and expand groups


### PR DESCRIPTION
I tried to use the group widget as an attribute for Isotope products and it works great, but with a little tweak. The Isotope product palette name can be an integer and it would result in `TypeError`. If we cast it explicitly to the string value, then everything works like a charm.

I did not run unit tests due to some other error, but those shouldn't be affected.

Do you think this can be merged anytime soon? 🙂