### PR TITLE
Fix undefined variable

### DIFF
--- a/src/Group/Registry.php
+++ b/src/Group/Registry.php
@@ -135,8 +135,8 @@ class Registry
             return null;
         }
 
-        $pidColumn = $dca['config']['langPid'] ?? 'langPid';
-        $languageColumn = $dca['config']['langColumnName'] ?? 'language';
+        $pidColumn = $GLOBALS['TL_DCA'][$table]['config']['langPid'] ?? 'langPid';
+        $languageColumn = $GLOBALS['TL_DCA'][$table]['config']['langColumnName'] ?? 'language';
 
         $result = $this->connection->fetchOne(
             sprintf(


### PR DESCRIPTION
Found an error when trying to use the groupwidget with multilanguage, because **$dca** is an undefined variable. We have stored it as `lang_pid` instead of `langPid` in the database.