### PR TITLE
Contao 5.3 compat

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "doctrine/dbal": "^2.12 || ^3.0",
     "doctrine/inflector": "^1.4 || ^2.0",
     "doctrine/orm": "^2.6",
-    "psr/container": "^1.0",
+    "psr/container": "^1.0 || ^2.0",
     "symfony/config": "^4.4 || ^5.0 || ^6.0",
     "symfony/dependency-injection": "^4.4 || ^5.0 || ^6.0",
     "symfony/property-access": "^4.4 || ^5.0 || ^6.0",


### PR DESCRIPTION
Contao 5.3 requires `"psr/container": "^2.0"` while the group widget only allows `"psr/container": "^1.0"`. I've added `|| ^2.0`.

I've tested this with 5.3.x-dev and couldn't detect any issues.