### PR TITLE
Fix Implicitly marking parameter $storage as nullable warning

### DIFF
--- a/src/Group/Registry.php
+++ b/src/Group/Registry.php
@@ -89,7 +89,7 @@ class Registry
         );
     }
 
-    private function createGroup(string $table, int $rowId, string $name, StorageInterface $storage = null): Group
+    private function createGroup(string $table, int $rowId, string $name, ?StorageInterface $storage = null): Group
     {
         $group = new Group($this->twig, $table, $rowId, $name);
         $group->setStorage($storage ?? $this->createStorage($table, $name, $group));


### PR DESCRIPTION
This PR fix a  Implicitly marking parameter $storage as nullable deprecation warning.