### PR TITLE
Fix paths in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /node_modules/
 /vendor/
 /vendor-bin/*/vendor
-./.phpunit.result.cache
-./composer.lock
-./yarn.lock
+/.phpunit.result.cache
+/composer.lock
+/yarn.lock
+


### PR DESCRIPTION
Was this intentional? Does not work on macOS.